### PR TITLE
Add annotations to Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
           load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
This pull request makes a minor update to the CI workflow configuration. The change adds support for passing build annotations to the Docker build process, which can help with tracking and debugging builds.

* CI workflow enhancement:
  * [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR159): Added the `annotations` field to the Docker build step, using metadata output from previous steps.