### PR TITLE
Fix package deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,6 @@ lint-fix:
 security:
 	@echo "Running security checks..."
 	python -m bandit -r src/ || true
-	python -m safety check || true
 
 # Build Docker image
 build:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -195,7 +195,7 @@ The project uses GitHub Actions for automated testing and deployment:
 The project uses GitHub's automatic release notes generation with custom categorization configured in `.github/release.yml`. PRs are automatically grouped into the following categories:
 
 - **🚀 Features** - New features and enhancements
-- **🐛 Bug Fixes** - Bug fixes and corrections  
+- **🐛 Bug Fixes** - Bug fixes and corrections
 - **🔒 Security** - Security-related changes
 - **📦 Dependency Updates** - Renovate and dependency updates
 - **🔧 Maintenance** - Refactoring and maintenance tasks
@@ -233,7 +233,7 @@ The configuration automatically groups Renovate dependency updates under "📦 D
 ## Security
 
 - **Non-root execution**: Container runs as UID 1000
-- **Dependency scanning**: Automated security checks with Bandit and Safety
+- **Dependency scanning**: Automated security checks with Bandit
 - **Input validation**: Safe filename handling and path traversal protection
 - **Resource limits**: Configurable processing limits
 
@@ -242,7 +242,7 @@ The configuration automatically groups Renovate dependency updates under "📦 D
 ### Common Development Issues
 
 1. **Tests failing**: Check FFmpeg installation and network connectivity
-2. **Permission errors**: Ensure proper file permissions for input/output directories  
+2. **Permission errors**: Ensure proper file permissions for input/output directories
 3. **Container issues**: Verify Docker daemon is running and accessible
 4. **Linting errors**: Run `make lint-fix` to auto-fix formatting issues
 

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -1,7 +1,7 @@
 # vidaud Requirements
 
 ## Implementation Status
-**Current Version**: 1.0.0 ✅  
+**Current Version**: 1.0.0 ✅
 **All core requirements implemented and tested**
 
 | Ref | Requirement | MoSCoW Priority | Status | Implementation Notes |
@@ -33,7 +33,7 @@
 | **NF3** | Avoid duplicate processing of same file | **Must** | ✅ **DONE** | MD5 hashing and `SKIP_EXISTING=true` |
 | **NF4** | Multi-arch Docker images (ARM & x86_64) | **Should** | ✅ **DONE** | Built for `linux/amd64` and `linux/arm64` |
 | **NF5** | Run as non-root | **Must** | ✅ **DONE** | UID 1000 user with proper permissions |
-| **NF6** | Keep dependencies up to date & free from vulnerabilities | **Must** | ✅ **DONE** | Renovate + Bandit + Safety scanning |
+| **NF6** | Keep dependencies up to date & free from vulnerabilities | **Must** | ✅ **DONE** | Renovate + Bandit scanning |
 | **NF7** | Clean, modular, documented codebase | **Must** | ✅ **DONE** | Comprehensive documentation and type hints |
 | **NF8** | Detailed logs with timestamps and file paths | **Must** | ✅ **DONE** | Structured logging with context |
 | **NF9** | Configurable output formats beyond MP3/FLAC | **Could** | ⏳ **FUTURE** | Currently supports MP3 (320kbps) and FLAC |

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,9 @@ mutagen==1.47.0
 fastapi==0.116.1
 uvicorn==0.35.0
 pydantic==2.11.7
-pytest==7.4.4
-pytest-asyncio==0.26.0
-pytest-cov==4.1.0
+pytest==8.4.1
+pytest-asyncio==1.1.0
+pytest-cov==6.2.1
 requests==2.32.4
 xxhash==3.5.0
 
@@ -17,4 +17,3 @@ black==24.10.0
 
 # Security scanning tools
 bandit==1.8.6
-safety==3.6.0


### PR DESCRIPTION
This pull request removes the use of Safety for dependency vulnerability scanning from the project, updating documentation and build scripts to reflect this change. Bandit remains as the primary tool for automated security checks.

**Security tooling updates:**

* Removed the invocation of Safety from the `security` target in the `Makefile`, so only Bandit is used for security checks now.
* Updated documentation in `docs/CONTRIBUTING.md` and `docs/REQUIREMENTS.md` to remove references to Safety and clarify that dependency scanning is handled by Bandit (and Renovate for updates). [[1]](diffhunk://#diff-4c6b93aa75d5affde60dc3849606c9acd75ed444d52e99f3055fc0c7aa77e9e0L236-R236) [[2]](diffhunk://#diff-ec360347eb95e17859836037adabfd8080b2e9336f369a6a0d4437c2d24f6a89L36-R36)